### PR TITLE
Fixes #2: Night mode - Issue

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,7 +17,11 @@ import logging
 
 ### Load config data here
 config = mw.addonManager.getConfig(__name__)
-primary_color = config['primary_color'] or "#0093d0";
+## Addon compatibility fixes
+# More Overview Stats 2.1 addon compatibility fix
+addon_more_overview_stats_fix = config['addon_more_overview_stats'].lower()
+## Customization
+primary_color = config['primary_color']
 custom_style = """
     <style>
         :root,
@@ -73,6 +77,8 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         web_content.css.append(f"/_addons/{addon_package}/files/BottomBar.css")
     # Overview
     elif isinstance(context, Overview):
+        if (addon_more_overview_stats_fix == "true"):
+            web_content.head += "<style>center > table tr:first-of-type {display: table-row; flex-direction: unset;}</style>"
         web_content.css.append(f"/_addons/{addon_package}/files/Overview.css")
     # Editor
     elif isinstance(context, Editor):

--- a/config.json
+++ b/config.json
@@ -1,1 +1,4 @@
-{ "primary_color": "#0093d0" }
+{
+  "addon_more_overview_stats": "true",
+  "primary_color": "#0093d0"
+}

--- a/config.md
+++ b/config.md
@@ -1,3 +1,4 @@
 This is documentation for this add-on's configuration:
 
-- primary_color: color
+- addon_more_overview_stats: either `true` or `false`
+- primary_color: customize own color here

--- a/files/global.css
+++ b/files/global.css
@@ -1,7 +1,22 @@
 :root,
-:root .isMac {
-  --focus-color: rgba(119, 204, 255, 0.7);
+:root .isWin,
+:root .isMac,
+:root .isLin {
+  --focus-color: rgba(81, 135, 169, 0.7);
+}
+/* Force LIGHT MODE Background */
+:root body:not(.nightMode),
+:root body.isWin:not(.nightMode),
+:root body.isMac:not(.nightMode),
+:root body.isLin:not(.nightMode) {
   --window-bg: #fafafa;
+}
+/* Force DARK MODE Background */
+:root body.nightMode,
+:root body.isWin.nightMode,
+:root body.isMac.nightMode,
+:root body.isLin.nightMode {
+  --window-bg: #2f2f31;
 }
 body {
   background-color: var(--window-bg);


### PR DESCRIPTION
After excessively debugging and testing each and every addon the issuer had enabled, it seems that there wasn't any major compatibility issues that causes the incorrect design. The problem was however found through a fault in my CSS styling, specifically targeting Mac computers. This PR fixes issue #2 by changing the CSS selector to force the design by either light or dark mode on all operating systems.

As part of the debugging, another styling fault was also found with the addon `More Overview Stats 2.1`. This PR also includes the hotfix for when the addon is used through a configuration file and setting the configuration key `"addon_more_overview_stats"` to either `true`/`false`.

closes #2 