### PR TITLE
Fixes #3: Addon doesnt work on 2.1.22

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-  "addon_more_overview_stats": "true",
+  "addon_more_overview_stats": "false",
   "primary_color": "#0093d0"
 }

--- a/files/BottomBar.css
+++ b/files/BottomBar.css
@@ -1,5 +1,5 @@
 body #outer button {
-  color: var(--text-fg);
+  color: var(--text-fg, var(--legacy-text-fg));
   border: none;
   border-radius: 15px;
   padding: 6px 24px;
@@ -11,25 +11,25 @@ body #outer button {
   letter-spacing: 0.02857em;
   text-transform: uppercase;
   min-width: 64px;
-  background-color: var(--frame-bg);
+  background-color: var(--frame-bg, var(--legacy-frame-bg));
   transition: background 0.2s linear, color 0.3s ease-out;
   box-shadow: rgb(0 0 0 / 20%) 0px 3px 7px -2px,
     rgb(0 0 0 / 5%) 0px 5px 10px 0px, rgb(0 0 0 / 12%) 0px 1px 5px 0px;
 }
 body.nightMode #outer button {
   background: initial;
-  background-color: var(--frame-bg);
+  background-color: var(--frame-bg, var(--legacy-frame-bg));
 }
 
 body #outer button:focus,
 body #outer button.focus {
   background-color: var(--primary-color);
-  color: var(--frame-bg);
+  color: var(--frame-bg, var(--legacy-frame-bg));
   outline: none;
 }
 body.nightMode #outer button:focus,
 body.nightMode #outer button.focus {
-  color: var(--text-fg);
+  color: var(--text-fg, var(--legacy-text-fg));
 }
 
 body #outer button:hover {

--- a/files/DeckBrowser.css
+++ b/files/DeckBrowser.css
@@ -18,7 +18,7 @@ body table:first-of-type tr.current {
   background-color: transparent;
 }
 body table:first-of-type tr.current td {
-  background-color: var(--faint-border);
+  background-color: var(--faint-border, var(--legacy-faint-border));
 }
 body table:first-of-type tr.current td:first-of-type {
   border-radius: 10px 0 0 10px;

--- a/files/Overview.css
+++ b/files/Overview.css
@@ -21,7 +21,7 @@ button#study.but {
   width: 100%;
   margin-bottom: 20px;
 
-  color: var(--text-fg);
+  color: var(--text-fg, var(--legacy-text-fg));
   border: none;
   border-radius: 15px;
   margin: 0 5px;
@@ -33,7 +33,7 @@ button#study.but {
   text-transform: uppercase;
   min-width: 64px;
   background: initial;
-  background-color: var(--frame-bg);
+  background-color: var(--frame-bg, var(--legacy-frame-bg));
   transition: background 0.2s linear, color 0.3s ease-out;
   box-shadow: rgb(0 0 0 / 20%) 0px 3px 7px -2px,
     rgb(0 0 0 / 5%) 0px 5px 10px 0px, rgb(0 0 0 / 12%) 0px 1px 5px 0px;
@@ -43,7 +43,7 @@ body.nightMode button#study.but:hover {
 }
 button#study.but:focus {
   background-color: var(--primary-color) !important;
-  color: var(--frame-bg);
+  color: var(--frame-bg, var(--legacy-frame-bg));
   outline: none;
 }
 body.nightMode button#study.but:focus {

--- a/files/ReviewerBottomBar.css
+++ b/files/ReviewerBottomBar.css
@@ -10,6 +10,7 @@ body button {
 body .stat {
   position: relative;
   padding-top: 0px;
+  min-width: 120px;
 }
 body .stat2 {
   padding-top: 0px;

--- a/files/TopToolbar.css
+++ b/files/TopToolbar.css
@@ -6,13 +6,13 @@ body center #header {
   width: auto;
   border-bottom: none;
   border-radius: 0 0 12px 12px;
-  background-color: var(--frame-bg);
+  background-color: var(--frame-bg, var(--legacy-frame-bg));
   height: 40px;
   box-shadow: rgb(0 0 0 / 10%) 0px 0px 11px -2px,
     rgb(0 0 0 / 14%) 0px 2px 2px 0px, rgb(0 0 0 / 12%) 0px 4px 5px 0px;
 }
 body.nightMode center #header {
-  background-color: var(--faint-border);
+  background-color: var(--faint-border, var(--legacy-faint-border));
 }
 body center #header .hitem {
   padding-left: initial;

--- a/files/global.css
+++ b/files/global.css
@@ -10,6 +10,40 @@
 :root body.isMac:not(.nightMode),
 :root body.isLin:not(.nightMode) {
   --window-bg: #fafafa;
+  /* Force variable styling on legacy versions */
+  --legacy-text-fg: black;
+  --legacy-frame-bg: white;
+  --legacy-border: #aaa;
+  --legacy-medium-border: #b6b6b6;
+  --legacy-faint-border: #e7e7e7;
+  --legacy-link: #00a;
+  --legacy-review-count: #0a0;
+  --legacy-new-count: #00a;
+  --legacy-learn-count: #c35617;
+  --legacy-zero-count: #ddd;
+  --legacy-slightly-grey-text: #333;
+  --legacy-highlight-bg: #77ccff;
+  --legacy-highlight-fg: black;
+  --legacy-disabled: #777;
+  --legacy-flag1-fg: #e25252;
+  --legacy-flag2-fg: #ffb347;
+  --legacy-flag3-fg: #54c414;
+  --legacy-flag4-fg: #578cff;
+  --legacy-flag5-fg: #ff82ee;
+  --legacy-flag6-fg: #00d1b5;
+  --legacy-flag7-fg: #9649dd;
+  --legacy-flag1-bg: #ff9b9b;
+  --legacy-flag2-bg: #ffb347;
+  --legacy-flag3-bg: #93e066;
+  --legacy-flag4-bg: #9dbcff;
+  --legacy-flag5-bg: #f5a8eb;
+  --legacy-flag6-bg: #7edbd7;
+  --legacy-flag7-bg: #cca3f1;
+  --legacy-buried-fg: #aaaa33;
+  --legacy-suspended-fg: #dd0;
+  --legacy-suspended-bg: #ffffb2;
+  --legacy-marked-bg: #cce;
+  --legacy-tooltip-bg: #fcfcfc;
 }
 /* Force DARK MODE Background */
 :root body.nightMode,
@@ -17,7 +51,45 @@
 :root body.isMac.nightMode,
 :root body.isLin.nightMode {
   --window-bg: #2f2f31;
+  /* Force variable styling on legacy versions */
+  --legacy-text-fg: white;
+  --legacy-frame-bg: #3a3a3a;
+  --legacy-border: #777;
+  --legacy-medium-border: #444;
+  --legacy-faint-border: #29292b;
+  --legacy-link: #77ccff;
+  --legacy-review-count: #5ccc00;
+  --legacy-new-count: #77ccff;
+  --legacy-learn-count: #ff935b;
+  --legacy-zero-count: #444;
+  --legacy-slightly-grey-text: #ccc;
+  --legacy-highlight-bg: #77ccff;
+  --legacy-highlight-fg: white;
+  --legacy-disabled: #777;
+  --legacy-flag1-fg: #ff7b7b;
+  --legacy-flag2-fg: #f5aa41;
+  --legacy-flag3-fg: #86ce5d;
+  --legacy-flag4-fg: #6f9dff;
+  --legacy-flag5-fg: #f097e4;
+  --legacy-flag6-fg: #5ccfca;
+  --legacy-flag7-fg: #9f63d3;
+  --legacy-flag1-bg: #aa5555;
+  --legacy-flag2-bg: #ac653a;
+  --legacy-flag3-bg: #559238;
+  --legacy-flag4-bg: #506aa3;
+  --legacy-flag5-bg: #975d8f;
+  --legacy-flag6-bg: #399185;
+  --legacy-flag7-bg: #624b77;
+  --legacy-buried-fg: #777733;
+  --legacy-suspended-fg: #ffffb2;
+  --legacy-suspended-bg: #aaaa33;
+  --legacy-marked-bg: #77c;
+  --legacy-tooltip-bg: #272727;
 }
+
 body {
   background-color: var(--window-bg);
+}
+html {
+  font-size: 12px;
 }

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,10 @@
+def module_exists(module_name):
+    try:
+        __import__(module_name)
+    except ImportError:
+        return False
+    else:
+        return True
+
+def attribute_exists(object, attribute):
+    return attribute in object.__dict__


### PR DESCRIPTION
This PR fixes issue #3 by checking for the available gui_hooks before appending the hook changes. This means that the addon will use the old legacy hooks (instead of the new modern hooks if there are not to be found) to style the older Anki versions. 

Problems with some classes and functions such as `Browser` being imported from other places are also handled through a custom utility `module_exists` function. Addon should work on Anki version 2.1.22 as of now. 🥳

closes #3