### PR TITLE
Fixes #17: Show info fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The concept of this add-on was inspired by the following add-on and designs:
 
 **Changelog:**
 
+- 14-04-2022: Adds minor bugfix for showInfo function (v0.1.1)
 - 13-04-2022: Adds major update adding dialog configuration and QT theming as well as some bugfixes and code cleanup (v0.1.0)
 - 31-01-2022: Adds minor bugfixes and some code cleanup (v0.0.8)
 - 30-01-2022: Adds customized font support, dark titlebar for windows on dark mode, more minor styling fixes (v0.0.7)

--- a/__init__.py
+++ b/__init__.py
@@ -265,7 +265,7 @@ else:
 from aqt import mw, gui_hooks
 from aqt.qt import *
 from .config import config
-from aqt.utils import showInfo, tr
+from aqt.utils import showInfo
 from aqt.webview import AnkiWebView
 
 class ThemeEditor(QDialog):
@@ -538,7 +538,9 @@ class ConfigDialog(QDialog):
 
         # Reload view, show info and hide dialog
         mw.reset()
-        showInfo(tr.preferences_changes_will_take_effect_when_you())
+        # ShowInfo for both new and legacy support
+        showInfo(_("Changes will take effect when you restart Anki."))
+        #showInfo(tr.preferences_changes_will_take_effect_when_you())
         self.accept()
 
 def update_theme() -> None:

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "package": "anki-redesign",
   "ankiweb_id": "308574457",
   "author": "Shirajuki",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "homepage": "https://github.com/shirajuki/anki-redesign",
   "conflicts": ["308574457", "688199788"],
   "manifest_version": 2


### PR DESCRIPTION
This PR fixes issue #17 by fixing the showInfo method to display custom text, instead of using built in methods introduced in newer versions. Addon should properly work on Anki version 2.1.22 now. 🥳

closes #17 