### PR TITLE
Add compatibility support for 2.1.57 + bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Note3: If the addon is not updating try open anki while holding shift to turn of
 
 **Manually tested on the following Anki versions:**
 
+- 2.1.57
 - 2.1.56
 - 2.1.54
 - 2.1.50
@@ -24,7 +25,8 @@ Note3: If the addon is not updating try open anki while holding shift to turn of
 - [ ] Recheck "Full screen" add-on compatibility
 - [ ] Re-add windows dark titlebar
 - [ ] Add a public theme sharing site where users can upload their themes and possibly have them preinstalled alongside the add-on
-- [ ] Add styling support and fix themes for Anki 2.1.57
+- [ ] Add styling support for Anki 2.1.57
+- [ ] Fix themes to support Anki version post UI changes
 
 <br/>
 <div><img src="./screenshots/ui-half.png"></div>

--- a/__init__.py
+++ b/__init__.py
@@ -62,9 +62,12 @@ logger.debug(themes)
 themes_parsed = get_theme(theme)
 color_mode = 3 if theme_manager.get_night_mode() else 2  # 2 = light and 3 = dark
 
+# Dark title bar
+from .utils.dark_title_bar import set_dark_titlebar, set_dark_titlebar_qt, dwmapi
+set_dark_titlebar(mw, dwmapi)
+logger.debug(dwmapi)
+
 # CSS injections
-
-
 def load_custom_style():
     # Theme config
     theme_colors_light = ""
@@ -197,47 +200,41 @@ elif attribute_exists(gui_hooks, "top_toolbar_did_init_links"):
 def on_dialog_manager_did_open_dialog(dialog_manager: DialogManager, dialog_name: str, dialog_instance: QWidget) -> None:
     logger.debug(dialog_name)
     dialog: AnkiQt = dialog_manager._dialogs[dialog_name][1]
+    # If dwmapi found and nightmode is enabled, set dark titlebar to dialog window
+    set_dark_titlebar_qt(dialog, dwmapi)
     # AddCards
     if dialog_name == "AddCards":
         context: AddCards = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QAddCards'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QAddCards'], encoding='utf-8').read())
     # Addons popup
     elif dialog_name == "AddonsDialog":
         context: AddonsDialog = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QAddonsDialog'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QAddonsDialog'], encoding='utf-8').read())
     # Browser
     elif dialog_name == "Browser":
         context: Browser = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QBrowser'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QBrowser'], encoding='utf-8').read())
     # EditCurrent
     elif dialog_name == "EditCurrent":
         context: EditCurrent = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QEditCurrent'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QEditCurrent'], encoding='utf-8').read())
     # FilteredDeckConfigDialog
     elif module_exists("aqt.filtered_deck") and dialog_name == "FilteredDeckConfigDialog":
         context: FilteredDeckConfigDialog = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QFilteredDeckConfigDialog'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QFilteredDeckConfigDialog'], encoding='utf-8').read())
     # Statistics / NewDeckStats
     elif dialog_name == "NewDeckStats":
         context: NewDeckStats = dialog_manager._dialogs[dialog_name][1]
         context.form.web.eval(load_custom_style_wrapper())
-        context.setStyleSheet(
-            open(css_files_dir['QNewDeckStats'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QNewDeckStats'], encoding='utf-8').read())
     # About
     elif dialog_name == "About":
         context: ClosableQDialog = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QAbout'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QAbout'], encoding='utf-8').read())
     # Preferences
     elif dialog_name == "Preferences":
         context: Preferences = dialog_manager._dialogs[dialog_name][1]
-        context.setStyleSheet(
-            open(css_files_dir['QPreferences'], encoding='utf-8').read())
+        context.setStyleSheet(open(css_files_dir['QPreferences'], encoding='utf-8').read())
     # sync_log - 这是什么？？？
     elif dialog_name == "sync_log":
         pass
@@ -254,22 +251,19 @@ else:
     def monkey_setup_dialog_gc(obj: Any) -> None:
         obj.finished.connect(lambda: mw.gcWindow(obj))
         logger.debug(obj)
+        set_dark_titlebar_qt(obj, dwmapi)
         # AddCards
         if isinstance(obj, AddCards):
-            obj.setStyleSheet(
-                open(css_files_dir['QAddCards'], encoding='utf-8').read())
+            obj.setStyleSheet(open(css_files_dir['QAddCards'], encoding='utf-8').read())
         # EditCurrent
         elif isinstance(obj, EditCurrent):
-            obj.setStyleSheet(
-                open(css_files_dir['QEditCurrent'], encoding='utf-8').read())
+            obj.setStyleSheet(open(css_files_dir['QEditCurrent'], encoding='utf-8').read())
         # Statistics / DeckStats
         elif isinstance(obj, DeckStats):
-            obj.setStyleSheet(
-                open(css_files_dir['QNewDeckStats'], encoding='utf-8').read())
+            obj.setStyleSheet(open(css_files_dir['QNewDeckStats'], encoding='utf-8').read())
         # About
         elif isinstance(obj, ClosableQDialog):
-            obj.setStyleSheet(
-                open(css_files_dir['QAbout'], encoding='utf-8').read())
+            obj.setStyleSheet(open(css_files_dir['QAbout'], encoding='utf-8').read())
         # Preferences
         # Haven't found a solution for legacy preferences yet :c
     # Should be rare enough for other addons to also patch this I hope.
@@ -279,15 +273,15 @@ else:
     if attribute_exists(gui_hooks, "addons_dialog_will_show"):
         def on_addons_dialog_will_show(dialog: AddonsDialog) -> None:
             logger.debug(dialog)
-            dialog.setStyleSheet(
-                open(css_files_dir['QAddonsDialog'], encoding='utf-8').read())
+            set_dark_titlebar_qt(dialog, dwmapi)
+            dialog.setStyleSheet(open(css_files_dir['QAddonsDialog'], encoding='utf-8').read())
         gui_hooks.addons_dialog_will_show.append(on_addons_dialog_will_show)
     # Browser
     if attribute_exists(gui_hooks, "browser_will_show"):
         def on_browser_will_show(browser: Browser) -> None:
             logger.debug(browser)
-            browser.setStyleSheet(
-                open(css_files_dir['QBrowser'], encoding='utf-8').read())
+            set_dark_titlebar_qt(browser, dwmapi)
+            browser.setStyleSheet(open(css_files_dir['QBrowser'], encoding='utf-8').read())
         gui_hooks.browser_will_show.append(on_browser_will_show)
 
 # Test for 2.1.56

--- a/__init__.py
+++ b/__init__.py
@@ -171,23 +171,7 @@ def on_webview_will_set_content(web_content: WebContent, context: Optional[Any])
         web_content.body += "<div style='height: 14px; opacity: 0; pointer-events: none;'></div>"
         web_content.body += "<div id='padFix' style='height: 30px; opacity: 0; pointer-events: none;'><script>const e = document.getElementById('padFix');e.parentElement.removeChild(e);</script></div>"
         if anki_version >= (2, 1, 56):
-            web_content.body += """
-            <script>
-                (() => {
-                    const timeout = 10, time = 0;
-                    let check;
-                    check = setInterval(() => {
-                        const table = document.getElementById('innertable');
-                        if (table) {
-                            table.classList.add('new-qt6');
-                            time += 10;
-                        }
-                        time++;
-                        if (time >= 10) clearInterval(check);
-                    },1000)
-                })()
-            </script>
-            """
+            web_content.body = "<div class='new-qt6' style='display: none;'></div>"+web_content.body
         mw.bottomWeb.adjustHeightToFit()
     # CardLayout
     elif context_name_includes(context, "aqt.clayout.CardLayout"):

--- a/__init__.py
+++ b/__init__.py
@@ -99,10 +99,11 @@ def load_custom_style():
     }
     html {
         font-family: %s;
-        font-size: %spx;
+        font-size: %spx !important;
+        --font-size: %spx !important;
     }
 </style>
-    """ % (theme_colors_light, theme_colors_dark, font, config["font_size"])
+    """ % (theme_colors_light, theme_colors_dark, font, config["font_size"], config["font_size"])
     return custom_style
 
 
@@ -292,12 +293,13 @@ else:
 # Test for 2.1.56
 if attribute_exists(gui_hooks, "style_did_init"):
     def updateStyle(str):
-        logger.debug("helloooo"+str)
+        # logger.debug("helloooo"+str)
         return str
     gui_hooks.style_did_init.append(updateStyle)
 
 # Dialog updates
 def updateTheme(_):
+    logger.debug("updating theme")
     global theme, themes_parsed, color_mode
     config = get_config()
     theme = config['theme']

--- a/files/DeckBrowser.css
+++ b/files/DeckBrowser.css
@@ -40,7 +40,7 @@ body table:first-of-type tr a.filtered {
 }
 a.deck {
   padding: 5px 10px 5px 5px;
-  transition: padding 1s, background-color 0.5s, margin-right 1s;
+  transition: padding 1s, background-color 0.5s, margin-right 1s !important;
   border-radius: 6px;
   margin-right: 5px;
 }

--- a/files/Overview.css
+++ b/files/Overview.css
@@ -1,5 +1,6 @@
 body .descmid {
   text-align: center;
+  overflow-x: hidden;
 }
 center > table tr:first-of-type {
   display: flex;

--- a/files/ReviewerBottomBar.css
+++ b/files/ReviewerBottomBar.css
@@ -70,12 +70,16 @@ body #outer.arbb button {
 }
 
 /* 2.1.56 fix */
-body #outer .new-qt6 #middle td.stat2 .stattxt,
-body #outer .new-qt6 .stattxt#time {
+body .new-qt6 ~ #outer #middle td.stat2 .stattxt,
+body .new-qt6 ~ #outer .stattxt#time {
   top: -16px;
 }
-body #outer table#innertable.new-qt6 {
+body .new-qt6 ~ #outer table#innertable {
   transform: translateY(0);
+}
+
+body .new-qt6 ~ #outer  #middle table[cellspacing]  {
+  transform: translateY(-10px);
 }
 
 /* NDFS addon fix */

--- a/files/ReviewerBottomBar.css
+++ b/files/ReviewerBottomBar.css
@@ -61,12 +61,27 @@ body #outer.arbb .stat {
 body #outer.arbb table#innertable {
   padding: initial;
   width: calc(100% - 10px);
+  transform: translateY(8px) !important;
+  height: 50px;
+}
+body #outer.arbb table #middle {
+  transform: translateY(10px);
+}
+body #outer.arbb table #time {
+  display: inline-flex;
+  justify-content: center;
+  left: 50%;
+  transform: translate(-50%, calc(-100% - 12px))
+}
+body #outer.arbb table .stattxt {
+  transform: translate(-50%, -16px);
 }
 body #outer.arbb button {
   letter-spacing: 0.02857em;
   text-transform: uppercase;
   margin-left: 2px;
   margin-right: 2px;
+  transform: translateY(-8px);
 }
 
 /* 2.1.56 fix */

--- a/files/ReviewerBottomBar.css
+++ b/files/ReviewerBottomBar.css
@@ -65,6 +65,9 @@ body #outer.arbb table#innertable {
   height: 50px;
 }
 body #outer.arbb table #middle {
+  transform: translateY(0);
+}
+body .new-qt6 #outer.arbb table #middle {
   transform: translateY(10px);
 }
 body #outer.arbb table #time {
@@ -74,14 +77,17 @@ body #outer.arbb table #time {
   transform: translate(-50%, calc(-100% - 12px))
 }
 body #outer.arbb table .stattxt {
+  transform: translate(-50%, -30px);
+}
+body .new-qt6 #outer.arbb table .stattxt {
   transform: translate(-50%, -16px);
 }
-body #outer.arbb button {
+body #outer.arbb table button {
   letter-spacing: 0.02857em;
   text-transform: uppercase;
   margin-left: 2px;
   margin-right: 2px;
-  transform: translateY(-8px);
+  transform: translateY(-8px) !important;
 }
 
 /* 2.1.56 fix */

--- a/files/TopToolbar.css
+++ b/files/TopToolbar.css
@@ -2,7 +2,7 @@ body #outer {
   display: flex;
   justify-content: center;
 }
-body center #header {
+body #header {
   width: auto;
   border-bottom: none;
   border-radius: 0 0 12px 12px;
@@ -20,17 +20,39 @@ body center #header .tdcenter {
   border: initial;
   padding: 0 2px;
 }
-body center #header .hitem {
+body center #header .hitem,
+body .header .toolbar .hitem {
   padding: 4px 15px;
   background: transparent;
   color: var(--text-fg, var(--legacy-text-fg)) !important;
   transition: background 0.3s;
   border-radius: 6px;
 }
-body center #header .hitem:hover {
+body center #header .hitem:hover,
+body .header .toolbar .hitem:hover {
   background: var(--button-bg);
   box-shadow: initial;
 }
-body center #header a#sync {
+body center #header a#sync,
+body .header .toolbar a#sync {
   color: var(--link, var(--legacy-link)) !important;
+}
+
+/* >= 2.1.57 */
+body:not(.fancy) .header {
+  border-bottom: 1px solid transparent !important;
+}
+body .header .toolbar {
+  width: auto;
+  border-bottom: none;
+  border-radius: 0 0 12px 12px;
+  background-color: var(--frame-bg, var(--legacy-frame-bg));
+  height: 34px;
+  padding: 4px 8px 4px 8px;
+  box-shadow: rgb(0 0 0 / 10%) 0px 0px 11px -2px,
+    rgb(0 0 0 / 14%) 0px 2px 2px 0px, rgb(0 0 0 / 12%) 0px 4px 5px 0px;
+}
+body:not(.fancy) .header .toolbar {
+  height: 30px;
+  padding: 2px 8px 2px 8px;
 }

--- a/files/global.css
+++ b/files/global.css
@@ -93,7 +93,7 @@ body {
   background-color: var(--window-bg) !important;
 }
 html {
-  font-size: var(--font-size, 12px);
+  font-size: var(--font-size, 12px) !important;
 }
 html body a {
   color: var(--link, var(--legacy-link)) !important;

--- a/themes/Catppuccin-Frappé.json
+++ b/themes/Catppuccin-Frappé.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#e78284",
+      "#ca9ee6",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#ef9f76",
+      "#e78284",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#e5c890",
+      "#ef9f76",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#45475a",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#51576d",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#51576d",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#414559",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#414559",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#292c3c",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
+      "",
       "#f99988",
       "#171922",
       "--button-focus-bg"
     ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#292c3c",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#292c3c",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#292c3c",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#f99988",
+      "#171922",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#f99988",
+      "#171922",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#f99988",
+      "#171922",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#f99988",
+      "#171922",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafbfc",
+      "#303446",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "#fcfdff",
+      "#232634",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "#fcfdff",
+      "#292c3c",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "#fcfdff",
+      "#232634",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#414559",
+      "--canvas-overlay"
+    ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
-      "#232634",
+      "",
+      "#fcfdff",
+      "#292c3c",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#838ba7",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#414559",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "#1f1f1f",
+      "#cdd6f4",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#838ba7",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#838ba7",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#e58e7d",
+      "#f2d5cf",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#838ba7",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#e78284",
       "#ca9ee6",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#e78284",
       "#ca9ee6",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#ef9f76",
       "#e78284",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#ef9f76",
       "#e78284",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#e5c890",
       "#ef9f76",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#e5c890",
       "#ef9f76",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#a6d189",
       "#e5c890",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#a6d189",
       "#e5c890",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#99d1db",
       "#a6d189",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#99d1db",
       "#a6d189",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#99d1db",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#99d1db",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
+      "",
       "#ca9ee6",
       "#8caaee",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#ca9ee6",
       "#8caaee",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#e78284",
+      "#ca9ee6",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#ef9f76",
+      "#e78284",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#e5c890",
+      "#ef9f76",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#a6d189",
+      "#e5c890",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#99d1db",
+      "#a6d189",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#85c1dc",
+      "#99d1db",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#ca9ee6",
+      "#8caaee",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
-      "#ea999c",
+      "#232634",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "#fcfdff",
-      "#232634",
+      "#292c3c",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#e78f7e",
-      "#8caaee",
+      "#626880",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "#black",
       "#b5bfe2",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#d20f39",
       "#e78284",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#e58e7d",
       "#f2d5cf",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#51576d",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#1e66f5",
       "#8caaee",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#40a02b",
       "#a6d189",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "#fcfdff",
+      "#232634",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#626880",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#45475a",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#e78f7e",
+      "#626880",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "#black",
+      "#b5bfe2",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#232634",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#232634",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#232634",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#232634",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#a5adce",
+      "",
+      "#777",
+      "#838ba7",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#d20f39",
+      "#e78284",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#1e66f5",
+      "#8caaee",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#40a02b",
+      "#a6d189",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "#1f1f1f",
       "#cdd6f4",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
-      "#626880",
+      "#414559",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafbfc",
       "#303446",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#8c8fa1",
-      "#949cbb",
+      "",
+      "#aaa",
+      "#45475a",
       "--zero-count"
     ]
   },

--- a/themes/Catppuccin-Macchiato.json
+++ b/themes/Catppuccin-Macchiato.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#e78284",
+      "#c6a0f6",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#ef9f76",
+      "#ed8796",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#e5c890",
+      "#f5a97f",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#494d64",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#363a4f",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#363a4f",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#1e2030",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#363a4f",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#1e2030",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
+      "",
       "#f99988",
       "#0b0b12",
       "--button-focus-bg"
     ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#1e2030",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#1e2030",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#1e2030",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafbfc",
+      "#24273a",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "fcfdff",
+      "#181926",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "fcfdff",
+      "#1e2030",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "fcfdff",
+      "#181926",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#363a4f",
+      "--canvas-overlay"
+    ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
+      "",
+      "fcfdff",
       "#181926",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#8087a2",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#1e2030",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "1f1f1f",
+      "#cad3f5",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#8087a2",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#8087a2",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#e58e7d",
+      "#f4dbd6",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#8087a2",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#e78284",
       "#c6a0f6",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#e78284",
       "#c6a0f6",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#ef9f76",
       "#ed8796",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#ef9f76",
       "#ed8796",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#e5c890",
       "#f5a97f",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#e5c890",
       "#f5a97f",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#a6d189",
       "#eed49f",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#a6d189",
       "#eed49f",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#99d1db",
       "#a6da95",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#99d1db",
       "#a6da95",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#91d7e3",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#91d7e3",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
+      "",
       "#ca9ee6",
       "#8aadf4",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#ca9ee6",
       "#8aadf4",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#e78284",
+      "#c6a0f6",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#ef9f76",
+      "#ed8796",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#e5c890",
+      "#f5a97f",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#a6d189",
+      "#eed49f",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#99d1db",
+      "#a6da95",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#85c1dc",
+      "#91d7e3",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#ca9ee6",
+      "#8aadf4",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
       "#ee99a0",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "fcfdff",
       "#181926",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#e78f7e",
-      "#8aadf4",
+      "#5b6078",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "black",
       "#bac2de",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#d20f39",
       "#ed8796",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#e58e7d",
       "#f4dbd6",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#363a4f",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#1e66f5",
       "#8aadf4",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#40a02b",
       "#a6da95",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "fcfdff",
+      "#181926",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#5b6078",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#494d64",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#e78f7e",
+      "#5b6078",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "black",
+      "#bac2de",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#181926",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#181926",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#181926",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#181926",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#b8c0e0",
+      "",
+      "#777",
+      "#8087a2",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#d20f39",
+      "#ed8796",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#1e66f5",
+      "#8aadf4",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#40a02b",
+      "#a6da95",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "1f1f1f",
       "#cad3f5",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
       "#5b6078",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafbfc",
       "#24273a",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#8c8fa1",
-      "#939ab7",
+      "",
+      "#aaa",
+      "#494d64",
       "--zero-count"
     ]
   },

--- a/themes/Catppuccin-Mocha.json
+++ b/themes/Catppuccin-Mocha.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#e78284",
+      "#cba6f7",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#ef9f76",
+      "#f38ba8",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#e5c890",
+      "#fab387",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#45475a",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#313244",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#313244",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#1A1826",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#313244",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#181825",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
+      "",
       "#f99988",
-      "#0b0b12",
+      "#11111b",
       "--button-focus-bg"
+    ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#181825",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#181825",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#181825",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#f99988",
+      "#11111b",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#f99988",
+      "#11111b",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#f99988",
+      "#11111b",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#f99988",
+      "#11111b",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafbfc",
+      "#1e1e2e",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "fcfdff",
+      "#11111b",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "fcfdff",
+      "#181825",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "fcfdff",
+      "#11111b",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#313244",
+      "--canvas-overlay"
     ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
+      "",
+      "fcfdff",
       "#181825",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#7f849c",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#1A1826",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "1f1f1f",
+      "#cdd6f4",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#7f849c",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#7f849c",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#e58e7d",
+      "#f5e0dc",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#7f849c",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#e78284",
       "#cba6f7",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#e78284",
       "#cba6f7",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#ef9f76",
       "#f38ba8",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#ef9f76",
       "#f38ba8",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#e5c890",
       "#fab387",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#e5c890",
       "#fab387",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#a6d189",
       "#f9e2af",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#a6d189",
       "#f9e2af",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#a6e3a1",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#a6e3a1",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#89dceb",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#89dceb",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
+      "",
       "#ca9ee6",
       "#89b4fa",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#ca9ee6",
       "#89b4fa",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#e78284",
+      "#cba6f7",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#ef9f76",
+      "#f38ba8",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#e5c890",
+      "#fab387",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#a6d189",
+      "#f9e2af",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#85c1dc",
+      "#a6e3a1",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#85c1dc",
+      "#89dceb",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#ca9ee6",
+      "#89b4fa",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
-      "#eba0ac",
+      "#11111b",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "fcfdff",
-      "#11111b",
+      "#181825",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#e78f7e",
-      "#89b4fa",
+      "#585b70",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "black",
       "#bac2de",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#d20f39",
       "#f38ba8",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#e58e7d",
       "#f5e0dc",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#313244",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#1e66f5",
       "#89b4fa",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#40a02b",
       "#a6e3a1",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "fcfdff",
+      "#11111b",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#585b70",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#45475a",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#e78f7e",
+      "#585b70",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "black",
+      "#bac2de",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#11111b",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#11111b",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#11111b",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#11111b",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#bac2de",
+      "",
+      "#777",
+      "#7f849c",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#d20f39",
+      "#f38ba8",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#1e66f5",
+      "#89b4fa",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#40a02b",
+      "#a6e3a1",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "1f1f1f",
       "#cdd6f4",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
-      "#585b70",
+      "#313244",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafbfc",
       "#1e1e2e",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#8c8fa1",
-      "#7f849c",
+      "",
+      "#aaa",
+      "#45475a",
       "--zero-count"
     ]
   },

--- a/themes/Catppuccin.json
+++ b/themes/Catppuccin.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#BF616A",
+      "#e78284",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#D08770",
+      "#ef9f76",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#A3BE8C",
+      "#e5c890",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#434c5e",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#434C5E",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#434C5E",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#1A1826",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#313244",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#1A1826",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
-      "#0093d0",
-      "#0093d0",
+      "",
+      "#e7e7e7",
+      "#1A1826",
       "--button-focus-bg"
+    ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#e7e7e7",
+      "#1A1826",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafafa",
+      "#1E1E2E",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "white",
+      "#333442",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "white",
+      "#181825",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "white",
+      "#333442",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#313244",
+      "--canvas-overlay"
     ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
-      "#1A1826",
+      "",
+      "white",
+      "#181825",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#C3BAC6",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#1A1826",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "black",
+      "#d9e0ee",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#C3BAC6",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#C3BAC6",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#6e9fda",
+      "#89DCEB",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#C3BAC6",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#BF616A",
       "#e78284",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#BF616A",
       "#e78284",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#D08770",
       "#ef9f76",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#D08770",
       "#ef9f76",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#A3BE8C",
       "#e5c890",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#A3BE8C",
       "#e5c890",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#5E81AC",
       "#a6d189",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#5E81AC",
       "#a6d189",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#B48EAD",
       "#99d1db",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#B48EAD",
       "#99d1db",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
-      "#7edbd7",
+      "",
+      "#00d1b5",
       "#8caaee",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#00d1b5",
       "#8caaee",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
-      "#cca3f1",
+      "",
+      "#9649dd",
       "#ca9ee6",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#9649dd",
       "#ca9ee6",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#BF616A",
+      "#e78284",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#D08770",
+      "#ef9f76",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#A3BE8C",
+      "#e5c890",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#5E81AC",
+      "#a6d189",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#B48EAD",
+      "#99d1db",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#00d1b5",
+      "#8caaee",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#9649dd",
+      "#ca9ee6",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
-      "#0093d0",
+      "#1e1e2e",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "white",
-      "#1A1826",
+      "#181825",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#77ccff",
-      "#81A1C1",
+      "#585b70",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "black",
       "#ECEFF4",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#c35617",
       "#D08770",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#6e9fda",
       "#89DCEB",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#434C5E",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#00a",
       "#5E81AC",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#0a0",
       "#A3BE8C",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "white",
+      "#1A1826",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#4C566A",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#434c5e",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#77ccff",
+      "#585b70",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "black",
+      "#ECEFF4",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#1e1e2e",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#181825",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#002a3b",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#000e14",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#D8DEE9",
+      "",
+      "#777",
+      "#C3BAC6",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#c35617",
+      "#D08770",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#00a",
+      "#5E81AC",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#0a0",
+      "#A3BE8C",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "black",
       "#d9e0ee",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
-      "#4C566A",
+      "#313244",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafafa",
       "#1E1E2E",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#ddd",
-      "#434C5E",
+      "",
+      "#aaa",
+      "#434c5e",
       "--zero-count"
     ]
   },

--- a/themes/Nord.json
+++ b/themes/Nord.json
@@ -1,229 +1,596 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#BF616A",
+      "#BF616A",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#D08770",
+      "#D08770",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#A3BE8C",
+      "#A3BE8C",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#D8DEE9",
       "#434C5E",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#E5E9F0",
+      "#434C5E",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#E5E9F0",
+      "#434C5E",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#ECEFF4",
+      "#3B4252",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
       "#D8DEE9",
       "#3B4252",
-      ""
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
+      "#D8DEE9",
+      "#3B4252",
+      "--button-disabled"
+    ],
+    "BUTTON_FOCUS_BG": [
+      "Button Focus Background",
+      "",
+      "#0093d0",
+      "#0093d0",
+      "--button-focus-bg"
+    ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#D8DEE9",
+      "#3B4252",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#D8DEE9",
+      "#3B4252",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#D8DEE9",
+      "#3B4252",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#0093d0",
+      "#434c5e",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#0093d0",
+      "#434c5e",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#0093d0",
+      "#434c5e",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#0093d0",
+      "#434c5e",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "white",
+      "#2E3440",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "#E5E9F0",
+      "#4c566a",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "#E5E9F0",
+      "#3B4252",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "#E5E9F0",
+      "#4c566a",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#D8DEE9",
+      "#4C566A",
+      "--canvas-overlay"
     ],
     "CURRENT_DECK": [
       "Selected Deck",
+      "",
       "#E5E9F0",
       "#3B4252",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#D8DEE9",
       "#D8DEE9",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#ECEFF4",
       "#3B4252",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "#2E3440",
+      "#E5E9F0",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#D8DEE9",
+      "#D8DEE9",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#D8DEE9",
+      "#D8DEE9",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#8FBCBB",
+      "#8FBCBB",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#D8DEE9",
+      "#D8DEE9",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#BF616A",
       "#BF616A",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#BF616A",
       "#BF616A",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#D08770",
       "#D08770",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#D08770",
       "#D08770",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#A3BE8C",
       "#A3BE8C",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#A3BE8C",
       "#A3BE8C",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#5E81AC",
       "#5E81AC",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#5E81AC",
       "#5E81AC",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#B48EAD",
       "#B48EAD",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#B48EAD",
       "#B48EAD",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
-      "#7edbd7",
-      "#399185",
+      "",
+      "#00d1b5",
+      "#5ccfca",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#00d1b5",
       "#5ccfca",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
-      "#cca3f1",
-      "#624b77",
+      "",
+      "#9649dd",
+      "#9f63d3",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#9649dd",
       "#9f63d3",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#BF616A",
+      "#BF616A",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#D08770",
+      "#D08770",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#A3BE8C",
+      "#A3BE8C",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#5E81AC",
+      "#5E81AC",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#B48EAD",
+      "#B48EAD",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#00d1b5",
+      "#5ccfca",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#9649dd",
+      "#9f63d3",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
-      "#0093d0",
+      "#2e3440",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "#E5E9F0",
       "#3B4252",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#81A1C1",
       "#81A1C1",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "white",
       "#ECEFF4",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#D08770",
       "#D08770",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#8FBCBB",
       "#8FBCBB",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#EBCB8B",
       "#EBCB8B",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#E5E9F0",
       "#434C5E",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#5E81AC",
       "#5E81AC",
       "--new-count"
     ],
     "PRIMARY_COLOR": [
       "Primary Color",
+      "",
       "#0093d0",
       "#0093d0",
       "--primary-color"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#A3BE8C",
       "#A3BE8C",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "#E5E9F0",
+      "#3B4252",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#D8DEE9",
+      "#4C566A",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#D8DEE9",
+      "#434C5E",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#81A1C1",
+      "#81A1C1",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "white",
+      "#ECEFF4",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#2e3440",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#2e3440",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#2e3440",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#2e3440",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#3B4252",
+      "",
+      "#D8DEE9",
       "#D8DEE9",
       "--slightly-grey-text"
     ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#D08770",
+      "#D08770",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#EBCB8B",
+      "#EBCB8B",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#5E81AC",
+      "#5E81AC",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#A3BE8C",
+      "#A3BE8C",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#3B4252",
+      "#ECEFF4",
+      "--state-suspended"
+    ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#88C0D0",
-      "#88C0D0",
+      "",
+      "#3B4252",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#3B4252",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "#2E3440",
       "#E5E9F0",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#D8DEE9",
       "#4C566A",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "white",
       "#2E3440",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
+      "",
       "#D8DEE9",
       "#434C5E",
       "--zero-count"

--- a/user_files/themes/Anki.json
+++ b/user_files/themes/Anki.json
@@ -52,8 +52,8 @@
     "BURIED_FG": [
       "Buried Foreground",
       "",
-      "#f59e0b",
-      "#92400e",
+      "#aaaa33",
+      "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
@@ -73,8 +73,8 @@
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
       "",
-      "#306bec",
-      "#2652cf",
+      "#0093d0",
+      "#0093d0",
       "--button-focus-bg"
     ],
     "BUTTON_GRADIENT_END": [
@@ -164,22 +164,22 @@
     "CURRENT_DECK": [
       "Selected Deck",
       "",
-      "#fcfcfc",
-      "#404040",
+      "#e7e7e7",
+      "#29292b",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
       "",
-      "#858585",
-      "#737373",
+      "#777",
+      "#777",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
       "",
-      "#e4e4e4",
-      "#252525",
+      "#e7e7e7",
+      "#29292b",
       "--faint-border"
     ],
     "FG": [
@@ -220,99 +220,99 @@
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
       "",
-      "#ef4444",
-      "#f87171",
+      "#ff9b9b",
+      "#aa5555",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (Browse Sidebar)",
       "",
-      "#ef4444",
-      "#f87171",
+      "#e25252",
+      "#ff7b7b",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
       "",
-      "#fb923c",
-      "#fdba74",
+      "#ffb347",
+      "#ac653a",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
       "",
-      "#fb923c",
-      "#fdba74",
+      "#ffb347",
+      "#f5aa41",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
       "",
-      "#4ade80",
-      "#86efac",
+      "#93e066",
+      "#559238",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
       "",
-      "#4ade80",
-      "#86efac",
+      "#54c414",
+      "#86ce5d",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
       "",
-      "#3b82f6",
-      "#60a5fa",
+      "#9dbcff",
+      "#506aa3",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
       "",
-      "#3b82f6",
-      "#60a5fa",
+      "#578cff",
+      "#6f9dff",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
       "",
-      "#e879f9",
-      "#f0abfc",
+      "#f5a8eb",
+      "#975d8f",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
       "",
-      "#e879f9",
-      "#f0abfc",
+      "#ff82ee",
+      "#f097e4",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
       "",
-      "#2dd4bf",
-      "#5eead4",
+      "#7edbd7",
+      "#399185",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
       "",
-      "#2dd4bf",
-      "#5eead4",
+      "#00d1b5",
+      "#5ccfca",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
       "",
-      "#a855f7",
-      "#c084fc",
+      "#cca3f1",
+      "#624b77",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
       "",
-      "#a855f7",
-      "#c084fc",
+      "#9649dd",
+      "#9f63d3",
       "--flag7-fg"
     ],
     "FLAG_1": [
@@ -367,15 +367,15 @@
     "FOCUS_SHADOW": [
       "Focus Shadow",
       "",
-      "#6366f1",
-      "#6366f1",
+      "#ff93d0",
+      "#0093d0",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
       "",
       "white",
-      "#363636",
+      "#3a3a3a",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
@@ -395,43 +395,43 @@
     "LEARN_COUNT": [
       "Learn Count",
       "",
-      "#dc2626",
-      "#f87171",
+      "#c35617",
+      "#ff935b",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
       "",
-      "#1d4ed8",
-      "#bfdbfe",
+      "#00a",
+      "#77ccff",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
       "",
-      "#6366f1",
-      "#a855f7",
+      "#cce",
+      "#77c",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
       "",
-      "#858585",
-      "#020202",
+      "#b6b6b6",
+      "#444",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
       "",
-      "#3b82f6",
-      "#93c5fd",
+      "#00a",
+      "#77ccff",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
       "",
-      "#16a34a",
-      "#22c55e",
+      "#0a0",
+      "#5ccc00",
       "--review-count"
     ],
     "SCROLLBAR_BG": [
@@ -500,8 +500,8 @@
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
       "",
-      "#afafaf",
-      "#545454",
+      "#333",
+      "#ccc",
       "--slightly-grey-text"
     ],
     "STATE_BURIED": [
@@ -549,43 +549,43 @@
     "SUSPENDED_BG": [
       "Suspended Background",
       "",
-      "#facc15",
-      "#fef9c3",
+      "#ffffb2",
+      "#aaaa33",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
       "",
-      "#facc15",
-      "#fef9c3",
+      "#dd0",
+      "#ffffb2",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
       "",
-      "#020202",
-      "#fcfcfc",
+      "black",
+      "white",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
       "",
       "#fcfcfc",
-      "#2c2c2c",
+      "#272727",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
       "",
-      "#f5f5f5",
-      "#2c2c2c",
+      "#fafafa",
+      "#2f2f31",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
       "",
-      "#c4c4c4",
-      "#202020",
+      "#ddd",
+      "#444",
       "--zero-count"
     ]
   },

--- a/user_files/themes/Catppuccin-Frappé.json
+++ b/user_files/themes/Catppuccin-Frappé.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#e78284",
+      "#ca9ee6",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#ef9f76",
+      "#e78284",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#e5c890",
+      "#ef9f76",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#45475a",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#51576d",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#51576d",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#414559",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#414559",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#292c3c",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
+      "",
       "#f99988",
       "#171922",
       "--button-focus-bg"
     ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#292c3c",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#292c3c",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#292c3c",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#f99988",
+      "#171922",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#f99988",
+      "#171922",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#f99988",
+      "#171922",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#f99988",
+      "#171922",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafbfc",
+      "#303446",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "#fcfdff",
+      "#232634",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "#fcfdff",
+      "#292c3c",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "#fcfdff",
+      "#232634",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#414559",
+      "--canvas-overlay"
+    ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
-      "#232634",
+      "",
+      "#fcfdff",
+      "#292c3c",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#838ba7",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#414559",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "#1f1f1f",
+      "#cdd6f4",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#838ba7",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#838ba7",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#e58e7d",
+      "#f2d5cf",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#838ba7",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#e78284",
       "#ca9ee6",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#e78284",
       "#ca9ee6",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#ef9f76",
       "#e78284",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#ef9f76",
       "#e78284",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#e5c890",
       "#ef9f76",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#e5c890",
       "#ef9f76",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#a6d189",
       "#e5c890",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#a6d189",
       "#e5c890",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#99d1db",
       "#a6d189",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#99d1db",
       "#a6d189",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#99d1db",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#99d1db",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
+      "",
       "#ca9ee6",
       "#8caaee",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#ca9ee6",
       "#8caaee",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#e78284",
+      "#ca9ee6",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#ef9f76",
+      "#e78284",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#e5c890",
+      "#ef9f76",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#a6d189",
+      "#e5c890",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#99d1db",
+      "#a6d189",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#85c1dc",
+      "#99d1db",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#ca9ee6",
+      "#8caaee",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
-      "#ea999c",
+      "#232634",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "#fcfdff",
-      "#232634",
+      "#292c3c",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#e78f7e",
-      "#8caaee",
+      "#626880",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "#black",
       "#b5bfe2",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#d20f39",
       "#e78284",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#e58e7d",
       "#f2d5cf",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#51576d",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#1e66f5",
       "#8caaee",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#40a02b",
       "#a6d189",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "#fcfdff",
+      "#232634",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#626880",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#45475a",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#e78f7e",
+      "#626880",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "#black",
+      "#b5bfe2",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#232634",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#232634",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#232634",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#232634",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#a5adce",
+      "",
+      "#777",
+      "#838ba7",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#d20f39",
+      "#e78284",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#1e66f5",
+      "#8caaee",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#40a02b",
+      "#a6d189",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "#1f1f1f",
       "#cdd6f4",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
-      "#626880",
+      "#414559",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafbfc",
       "#303446",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#8c8fa1",
-      "#949cbb",
+      "",
+      "#aaa",
+      "#45475a",
       "--zero-count"
     ]
   },

--- a/user_files/themes/Catppuccin-Macchiato.json
+++ b/user_files/themes/Catppuccin-Macchiato.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#e78284",
+      "#c6a0f6",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#ef9f76",
+      "#ed8796",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#e5c890",
+      "#f5a97f",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#494d64",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#363a4f",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#363a4f",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#1e2030",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#363a4f",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#1e2030",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
+      "",
       "#f99988",
       "#0b0b12",
       "--button-focus-bg"
     ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#1e2030",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#1e2030",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#1e2030",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#f99988",
+      "#0b0b12",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafbfc",
+      "#24273a",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "fcfdff",
+      "#181926",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "fcfdff",
+      "#1e2030",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "fcfdff",
+      "#181926",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#363a4f",
+      "--canvas-overlay"
+    ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
+      "",
+      "fcfdff",
       "#181926",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#8087a2",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#1e2030",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "1f1f1f",
+      "#cad3f5",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#8087a2",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#8087a2",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#e58e7d",
+      "#f4dbd6",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#8087a2",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#e78284",
       "#c6a0f6",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#e78284",
       "#c6a0f6",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#ef9f76",
       "#ed8796",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#ef9f76",
       "#ed8796",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#e5c890",
       "#f5a97f",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#e5c890",
       "#f5a97f",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#a6d189",
       "#eed49f",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#a6d189",
       "#eed49f",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#99d1db",
       "#a6da95",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#99d1db",
       "#a6da95",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#91d7e3",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#91d7e3",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
+      "",
       "#ca9ee6",
       "#8aadf4",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#ca9ee6",
       "#8aadf4",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#e78284",
+      "#c6a0f6",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#ef9f76",
+      "#ed8796",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#e5c890",
+      "#f5a97f",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#a6d189",
+      "#eed49f",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#99d1db",
+      "#a6da95",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#85c1dc",
+      "#91d7e3",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#ca9ee6",
+      "#8aadf4",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
       "#ee99a0",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "fcfdff",
       "#181926",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#e78f7e",
-      "#8aadf4",
+      "#5b6078",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "black",
       "#bac2de",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#d20f39",
       "#ed8796",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#e58e7d",
       "#f4dbd6",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#363a4f",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#1e66f5",
       "#8aadf4",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#40a02b",
       "#a6da95",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "fcfdff",
+      "#181926",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#5b6078",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#494d64",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#e78f7e",
+      "#5b6078",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "black",
+      "#bac2de",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#181926",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#181926",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#181926",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#181926",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#b8c0e0",
+      "",
+      "#777",
+      "#8087a2",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#d20f39",
+      "#ed8796",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#1e66f5",
+      "#8aadf4",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#40a02b",
+      "#a6da95",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "1f1f1f",
       "#cad3f5",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
       "#5b6078",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafbfc",
       "#24273a",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#8c8fa1",
-      "#939ab7",
+      "",
+      "#aaa",
+      "#494d64",
       "--zero-count"
     ]
   },

--- a/user_files/themes/Catppuccin-Mocha.json
+++ b/user_files/themes/Catppuccin-Mocha.json
@@ -1,231 +1,591 @@
 {
   "colors": {
+    "ACCENT_CARD": [
+      "Accent Card",
+      "Accent color for cards",
+      "#e78284",
+      "#cba6f7",
+      "--accent-card"
+    ],
+    "ACCENT_DANGER": [
+      "Accent Danger",
+      "Saturated accent color to grab attention",
+      "#ef9f76",
+      "#f38ba8",
+      "--accent-danger"
+    ],
+    "ACCENT_NOTE": [
+      "Accent Note",
+      "Accent color for notes",
+      "#e5c890",
+      "#fab387",
+      "--accent-note"
+    ],
     "BORDER": [
       "Border",
+      "",
       "#aaa",
       "#45475a",
       "--border"
     ],
+    "BORDER_FOCUS": [
+      "Border Focus",
+      "Border color of focused input elements",
+      "#b6b6b6",
+      "#313244",
+      "--border-focus"
+    ],
+    "BORDER_STRONG": [
+      "Border Strong",
+      "Border color with high contrast against window background",
+      "#b6b6b6",
+      "#313244",
+      "--border-strong"
+    ],
+    "BORDER_SUBTLE": [
+      "Border Subtle",
+      "Border color with low contrast against window background",
+      "#e7e7e7",
+      "#1A1826",
+      "--border-subtle"
+    ],
     "BURIED_FG": [
       "Buried Foreground",
+      "",
       "#aaaa33",
       "#777733",
       "--buried-fg"
     ],
     "BUTTON_BG": [
       "Button Background",
+      "",
+      "#e7e7e7",
+      "#313244",
+      "--button-bg"
+    ],
+    "BUTTON_DISABLED": [
+      "Button Disabled",
+      "Background color of disabled button",
       "#e7e7e7",
       "#181825",
-      "--button-bg"
+      "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
       "Button Focus Background",
+      "",
       "#f99988",
-      "#0b0b12",
+      "#11111b",
       "--button-focus-bg"
+    ],
+    "BUTTON_GRADIENT_END": [
+      "Button Gradient End",
+      "End value of default button gradient",
+      "#e7e7e7",
+      "#181825",
+      "--button-grandient-end"
+    ],
+    "BUTTON_GRADIENT_START": [
+      "Button Gradient Start",
+      "Start value of default button gradient",
+      "#e7e7e7",
+      "#181825",
+      "--button-gradient-start"
+    ],
+    "BUTTON_HOVER_BORDER": [
+      "Button Hover Border",
+      "Border color of default button in hover state",
+      "#e7e7e7",
+      "#181825",
+      "--button-hover-border"
+    ],
+    "BUTTON_PRIMARY_BG": [
+      "Button Primary Background",
+      "Background color of primary button",
+      "#f99988",
+      "#11111b",
+      "--button-primary-bg"
+    ],
+    "BUTTON_PRIMARY_DISABLED": [
+      "Button Primary Disabled",
+      "Background color of primary button in disabled state",
+      "#f99988",
+      "#11111b",
+      "--button-primary-disabled"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_END": [
+      "Button Primary Gradient End",
+      "End value of primary button gradient",
+      "#f99988",
+      "#11111b",
+      "--button-primary-gradient-end"
+    ],
+    "BUTTON_PRIMARY_GRADIENT_START": [
+      "Button Primary Gradient Start",
+      "Start value of primary button gradient",
+      "#f99988",
+      "#11111b",
+      "--button-primary-gradient-start"
+    ],
+    "CANVAS": [
+      "Canvas",
+      "Window background",
+      "#fafbfc",
+      "#1e1e2e",
+      "--canvas"
+    ],
+    "CANVAS_CODE": [
+      "Canvas code",
+      "Background of code editors",
+      "fcfdff",
+      "#11111b",
+      "--canvas-code"
+    ],
+    "CANVAS_ELEVATED": [
+      "Canvas Elevated",
+      "Background of containers",
+      "fcfdff",
+      "#181825",
+      "--canvas-elevated"
+    ],
+    "CANVAS_INSET": [
+      "Canvas Inset",
+      "Background of inputs inside containers",
+      "fcfdff",
+      "#11111b",
+      "--canvas-inset"
+    ],
+    "CANVAS_OVERLAY": [
+      "Canvas Overlay",
+      "Background of floating elements (menus, tooltips)",
+      "#fcfcfc",
+      "#313244",
+      "--canvas-overlay"
     ],
     "CURRENT_DECK": [
       "Selected Deck",
-      "#e7e7e7",
+      "",
+      "fcfdff",
       "#181825",
       "--current-deck"
     ],
     "DISABLED": [
       "Disabled",
+      "",
       "#777",
       "#7f849c",
       "--disabled"
     ],
     "FAINT_BORDER": [
       "Faint Border",
+      "",
       "#e7e7e7",
       "#1A1826",
       "--faint-border"
     ],
+    "FG": [
+      "Foreground",
+      "Default text/icon color",
+      "1f1f1f",
+      "#cdd6f4",
+      "--fg"
+    ],
+    "FG_DISABLED": [
+      "Foreground Disabled",
+      "Foreground color of disabled UI elements",
+      "#777",
+      "#7f849c",
+      "--fg-disabled"
+    ],
+    "FG_FAINT": [
+      "Foreground Faint",
+      "Foreground color that barely stands out against canvas",
+      "#777",
+      "#7f849c",
+      "--fg-faint"
+    ],
+    "FG_LINK": [
+      "Foreground Link",
+      "Hyperlink foreground color",
+      "#e58e7d",
+      "#f5e0dc",
+      "--fg-link"
+    ],
+    "FG_SUBTLE": [
+      "Foreground Subtle",
+      "Placeholder text, icons in idle state",
+      "#777",
+      "#7f849c",
+      "--fg-subtle"
+    ],
     "FLAG1_BG": [
       "Flag1 (Browse Cards List)",
+      "",
       "#e78284",
       "#cba6f7",
       "--flag1-bg"
     ],
     "FLAG1_FG": [
       "Flag1 (BrowseSidebar)",
+      "",
       "#e78284",
       "#cba6f7",
       "--flag1-fg"
     ],
     "FLAG2_BG": [
       "Flag2 (Browse Cards List)",
+      "",
       "#ef9f76",
       "#f38ba8",
       "--flag2-bg"
     ],
     "FLAG2_FG": [
       "Flag2 (Browse Sidebar)",
+      "",
       "#ef9f76",
       "#f38ba8",
       "--flag2-fg"
     ],
     "FLAG3_BG": [
       "Flag3 (Browse Cards List)",
+      "",
       "#e5c890",
       "#fab387",
       "--flag3-bg"
     ],
     "FLAG3_FG": [
       "Flag3 (Browse Sidebar)",
+      "",
       "#e5c890",
       "#fab387",
       "--flag3-fg"
     ],
     "FLAG4_BG": [
       "Flag4 (Browse Cards List)",
+      "",
       "#a6d189",
       "#f9e2af",
       "--flag4-bg"
     ],
     "FLAG4_FG": [
       "Flag4 (Browse Sidebar)",
+      "",
       "#a6d189",
       "#f9e2af",
       "--flag4-fg"
     ],
     "FLAG5_BG": [
       "Flag5 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#a6e3a1",
       "--flag5-bg"
     ],
     "FLAG5_FG": [
       "Flag5 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#a6e3a1",
       "--flag5-fg"
     ],
     "FLAG6_BG": [
       "Flag6 (Browse Cards List)",
+      "",
       "#85c1dc",
       "#89dceb",
       "--flag6-bg"
     ],
     "FLAG6_FG": [
       "Flag6 (Browse Sidebar)",
+      "",
       "#85c1dc",
       "#89dceb",
       "--flag6-fg"
     ],
     "FLAG7_BG": [
       "Flag7 (Browse Cards List)",
+      "",
       "#ca9ee6",
       "#89b4fa",
       "--flag7-bg"
     ],
     "FLAG7_FG": [
       "Flag7 (Browse Sidebar)",
+      "",
       "#ca9ee6",
       "#89b4fa",
       "--flag7-fg"
     ],
+    "FLAG_1": [
+      "Flag 1 (red)",
+      "",
+      "#e78284",
+      "#cba6f7",
+      "--flag-1"
+    ],
+    "FLAG_2": [
+      "Flag 2 (orange)",
+      "",
+      "#ef9f76",
+      "#f38ba8",
+      "--flag-2"
+    ],
+    "FLAG_3": [
+      "Flag 3 (green)",
+      "",
+      "#e5c890",
+      "#fab387",
+      "--flag-3"
+    ],
+    "FLAG_4": [
+      "Flag 4 (blue)",
+      "",
+      "#a6d189",
+      "#f9e2af",
+      "--flag-4"
+    ],
+    "FLAG_5": [
+      "Flag 5 (pink)",
+      "",
+      "#85c1dc",
+      "#a6e3a1",
+      "--flag-5"
+    ],
+    "FLAG_6": [
+      "Flag 6 (turquoise)",
+      "",
+      "#85c1dc",
+      "#89dceb",
+      "--flag-6"
+    ],
+    "FLAG_7": [
+      "Flag 7 (purple)",
+      "",
+      "#ca9ee6",
+      "#89b4fa",
+      "--flag-7"
+    ],
     "FOCUS_SHADOW": [
       "Focus Shadow",
+      "",
       "#ff93d0",
-      "#eba0ac",
+      "#11111b",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
+      "",
       "fcfdff",
-      "#11111b",
+      "#181825",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
+      "",
       "#e78f7e",
-      "#89b4fa",
+      "#585b70",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
       "Highlighted Text",
+      "",
       "black",
       "#bac2de",
       "--highlight-fg"
     ],
     "LEARN_COUNT": [
       "Learn Count",
+      "",
       "#d20f39",
       "#f38ba8",
       "--learn-count"
     ],
     "LINK": [
       "Hyperlink",
+      "",
       "#e58e7d",
       "#f5e0dc",
       "--link"
     ],
     "MARKED_BG": [
       "Marked Background",
+      "",
       "#cce",
       "#ebcb8b",
       "--marked-bg"
     ],
     "MEDIUM_BORDER": [
       "Medium Border",
+      "",
       "#b6b6b6",
       "#313244",
       "--medium-border"
     ],
     "NEW_COUNT": [
       "New Count",
+      "",
       "#1e66f5",
       "#89b4fa",
       "--new-count"
     ],
     "REVIEW_COUNT": [
       "Review Count",
+      "",
       "#40a02b",
       "#a6e3a1",
       "--review-count"
     ],
+    "SCROLLBAR_BG": [
+      "Scrollbar Background",
+      "Background of scrollbar in idle state (Win/Lin only)",
+      "fcfdff",
+      "#11111b",
+      "--scrollbar-bg"
+    ],
+    "SCROLLBAR_BG_ACTIVE": [
+      "Scrollbar Background Active",
+      "Background of scrollbar in pressed state (Win/Lin only)",
+      "#fcfcfc",
+      "#585b70",
+      "--scrollbar-bg-active"
+    ],
+    "SCROLLBAR_BG_HOVER": [
+      "Scrollbar Background Hover",
+      "Background of scrollbar in hover state (Win/Lin only)",
+      "#aaa",
+      "#45475a",
+      "--scrollbar-bg-hover"
+    ],
+    "SELECTED_BG": [
+      "Selected Background",
+      "Background color of selected text",
+      "#e78f7e",
+      "#585b70",
+      "--selected-bg"
+    ],
+    "SELECTED_FG": [
+      "Selected Foreground",
+      "Foreground color of selected text",
+      "black",
+      "#bac2de",
+      "--selected-fg"
+    ],
+    "SHADOW": [
+      "Shadow",
+      "Default box-shadow color",
+      "#ff93d0",
+      "#11111b",
+      "--shadow"
+    ],
+    "SHADOW_FOCUS": [
+      "Shadow Focus",
+      "Box-shadow color for elements in focused state",
+      "#ff93d0",
+      "#11111b",
+      "--shadow-focus"
+    ],
+    "SHADOW_INSET": [
+      "Shadow Inset",
+      "Inset box-shadow color",
+      "#ff93d0",
+      "#11111b",
+      "--shadow-inset"
+    ],
+    "SHADOW_SUBTLE": [
+      "Shadow Subtle",
+      "Box-shadow color with lower contrast against window background",
+      "#ff93d0",
+      "#11111b",
+      "--shadow-subtle"
+    ],
     "SLIGHTLY_GREY_TEXT": [
       "Switch Text",
-      "#333",
-      "#bac2de",
+      "",
+      "#777",
+      "#7f849c",
       "--slightly-grey-text"
+    ],
+    "STATE_BURIED": [
+      "State Buried",
+      "Accent color for buried cards",
+      "#aaaa33",
+      "#777733",
+      "--state-buried"
+    ],
+    "STATE_LEARN": [
+      "State Learn",
+      "Accent color for cards in learning state",
+      "#d20f39",
+      "#f38ba8",
+      "--state-learn"
+    ],
+    "STATE_MARKED": [
+      "State Marked",
+      "Accent color for marked cards",
+      "#cce",
+      "#ebcb8b",
+      "--state-marked"
+    ],
+    "STATE_NEW": [
+      "State New",
+      "Accent color for new cards",
+      "#1e66f5",
+      "#89b4fa",
+      "--state-new"
+    ],
+    "STATE_REVIEW": [
+      "State Review",
+      "Accent color for cards in review state",
+      "#40a02b",
+      "#a6e3a1",
+      "--state-review"
+    ],
+    "STATE_SUSPENDED": [
+      "State Suspended",
+      "Accent color for suspended cards",
+      "#dd0",
+      "#ECEFF4",
+      "--state-suspended"
     ],
     "SUSPENDED_BG": [
       "Suspended Background",
-      "#ffffb2",
-      "#161320",
+      "",
+      "#dd0",
+      "#ECEFF4",
       "--suspended-bg"
     ],
     "SUSPENDED_FG": [
       "Suspended Foreground",
+      "",
       "#dd0",
       "#ECEFF4",
       "--suspended-fg"
     ],
     "TEXT_FG": [
       "Text Foreground",
+      "",
       "1f1f1f",
       "#cdd6f4",
       "--text-fg"
     ],
     "TOOLTIP_BG": [
       "Tooltip Background",
+      "",
       "#fcfcfc",
-      "#585b70",
+      "#313244",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [
       "Window Background",
+      "",
       "#fafbfc",
       "#1e1e2e",
       "--window-bg"
     ],
     "ZERO_COUNT": [
       "Zero Count",
-      "#8c8fa1",
-      "#7f849c",
+      "",
+      "#aaa",
+      "#45475a",
       "--zero-count"
     ]
   },

--- a/user_files/themes/Catppuccin.json
+++ b/user_files/themes/Catppuccin.json
@@ -60,7 +60,7 @@
       "Button Background",
       "",
       "#e7e7e7",
-      "#1A1826",
+      "#313244",
       "--button-bg"
     ],
     "BUTTON_DISABLED": [
@@ -137,35 +137,35 @@
       "Canvas code",
       "Background of code editors",
       "white",
-      "#1A1826",
+      "#333442",
       "--canvas-code"
     ],
     "CANVAS_ELEVATED": [
       "Canvas Elevated",
       "Background of containers",
       "white",
-      "#1A1826",
+      "#181825",
       "--canvas-elevated"
     ],
     "CANVAS_INSET": [
       "Canvas Inset",
       "Background of inputs inside containers",
       "white",
-      "#1A1826",
+      "#333442",
       "--canvas-inset"
     ],
     "CANVAS_OVERLAY": [
       "Canvas Overlay",
       "Background of floating elements (menus, tooltips)",
       "#fcfcfc",
-      "#4C566A",
+      "#313244",
       "--canvas-overlay"
     ],
     "CURRENT_DECK": [
       "Selected Deck",
       "",
-      "#e7e7e7",
-      "#1A1826",
+      "white",
+      "#181825",
       "--current-deck"
     ],
     "DISABLED": [
@@ -368,21 +368,21 @@
       "Focus Shadow",
       "",
       "#ff93d0",
-      "#0093d0",
+      "#1e1e2e",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
       "Frame Background",
       "",
       "white",
-      "#1A1826",
+      "#181825",
       "--frame-bg"
     ],
     "HIGHLIGHT_BG": [
       "Highlighted Background",
       "",
       "#77ccff",
-      "#81A1C1",
+      "#585b70",
       "--highlight-bg"
     ],
     "HIGHLIGHT_FG": [
@@ -459,7 +459,7 @@
       "Selected Background",
       "Background color of selected text",
       "#77ccff",
-      "#81A1C1",
+      "#585b70",
       "--selected-bg"
     ],
     "SELECTED_FG": [
@@ -473,28 +473,28 @@
       "Shadow",
       "Default box-shadow color",
       "#ff93d0",
-      "#0093d0",
+      "#1e1e2e",
       "--shadow"
     ],
     "SHADOW_FOCUS": [
       "Shadow Focus",
       "Box-shadow color for elements in focused state",
       "#ff93d0",
-      "#0093d0",
+      "#181825",
       "--shadow-focus"
     ],
     "SHADOW_INSET": [
       "Shadow Inset",
       "Inset box-shadow color",
       "#ff93d0",
-      "#0093d0",
+      "#002a3b",
       "--shadow-inset"
     ],
     "SHADOW_SUBTLE": [
       "Shadow Subtle",
       "Box-shadow color with lower contrast against window background",
       "#ff93d0",
-      "#0093d0",
+      "#000e14",
       "--shadow-subtle"
     ],
     "SLIGHTLY_GREY_TEXT": [
@@ -571,7 +571,7 @@
       "Tooltip Background",
       "",
       "#fcfcfc",
-      "#4C566A",
+      "#313244",
       "--tooltip-bg"
     ],
     "WINDOW_BG": [

--- a/user_files/themes/Nord.json
+++ b/user_files/themes/Nord.json
@@ -61,7 +61,7 @@
       "",
       "#D8DEE9",
       "#3B4252",
-      ""
+      "--button-bg"
     ],
     "BUTTON_DISABLED": [
       "Button Disabled",
@@ -71,11 +71,11 @@
       "--button-disabled"
     ],
     "BUTTON_FOCUS_BG": [
-      "Button Primary Background",
-      "Background color of primary button",
-      "#D8DEE9",
-      "#3B4252",
-      "--button-primary-bg"
+      "Button Focus Background",
+      "",
+      "#0093d0",
+      "#0093d0",
+      "--button-focus-bg"
     ],
     "BUTTON_GRADIENT_END": [
       "Button Gradient End",
@@ -101,29 +101,29 @@
     "BUTTON_PRIMARY_BG": [
       "Button Primary Background",
       "Background color of primary button",
-      "#D8DEE9",
-      "#3B4252",
+      "#0093d0",
+      "#434c5e",
       "--button-primary-bg"
     ],
     "BUTTON_PRIMARY_DISABLED": [
       "Button Primary Disabled",
       "Background color of primary button in disabled state",
-      "#D8DEE9",
-      "#3B4252",
+      "#0093d0",
+      "#434c5e",
       "--button-primary-disabled"
     ],
     "BUTTON_PRIMARY_GRADIENT_END": [
       "Button Primary Gradient End",
       "End value of primary button gradient",
-      "#D8DEE9",
-      "#3B4252",
+      "#0093d0",
+      "#434c5e",
       "--button-primary-gradient-end"
     ],
     "BUTTON_PRIMARY_GRADIENT_START": [
       "Button Primary Gradient Start",
       "Start value of primary button gradient",
-      "#D8DEE9",
-      "#3B4252",
+      "#0093d0",
+      "#434c5e",
       "--button-primary-gradient-start"
     ],
     "CANVAS": [
@@ -137,7 +137,7 @@
       "Canvas code",
       "Background of code editors",
       "#E5E9F0",
-      "#3B4252",
+      "#4c566a",
       "--canvas-code"
     ],
     "CANVAS_ELEVATED": [
@@ -151,7 +151,7 @@
       "Canvas Inset",
       "Background of inputs inside containers",
       "#E5E9F0",
-      "#3B4252",
+      "#4c566a",
       "--canvas-inset"
     ],
     "CANVAS_OVERLAY": [
@@ -164,7 +164,7 @@
     "CURRENT_DECK": [
       "Selected Deck",
       "",
-      "#D8DEE9",
+      "#E5E9F0",
       "#3B4252",
       "--current-deck"
     ],
@@ -368,7 +368,7 @@
       "Focus Shadow",
       "",
       "#ff93d0",
-      "#0093d0",
+      "#2e3440",
       "--focus-shadow-color"
     ],
     "FRAME_BG": [
@@ -480,28 +480,28 @@
       "Shadow",
       "Default box-shadow color",
       "#ff93d0",
-      "#0093d0",
+      "#2e3440",
       "--shadow"
     ],
     "SHADOW_FOCUS": [
       "Shadow Focus",
       "Box-shadow color for elements in focused state",
       "#ff93d0",
-      "#0093d0",
+      "#2e3440",
       "--shadow-focus"
     ],
     "SHADOW_INSET": [
       "Shadow Inset",
       "Inset box-shadow color",
       "#ff93d0",
-      "#0093d0",
+      "#2e3440",
       "--shadow-inset"
     ],
     "SHADOW_SUBTLE": [
       "Shadow Subtle",
       "Box-shadow color with lower contrast against window background",
       "#ff93d0",
-      "#0093d0",
+      "#2e3440",
       "--shadow-subtle"
     ],
     "SLIGHTLY_GREY_TEXT": [

--- a/user_files/themes/readme.txt
+++ b/user_files/themes/readme.txt
@@ -1,0 +1,14 @@
+To create your own customized themes
+make a copy of Anki.json from ./themes to ./user_files/themes,
+name and edit it according to your wishes.
+
+User edited themes should be placed in the ./user_files/themes
+folder.
+
+This addon is also compatible with the themes of ReColor,
+which means that the uploaded community themes can also
+be downloaded and used:
+- https://github.com/AnKingMed/AnkiRecolor/wiki/Themes
+
+Place the downloaded themes in the ./user_files/themes folder 
+as well.

--- a/utils/dark_title_bar.py
+++ b/utils/dark_title_bar.py
@@ -2,22 +2,17 @@ from .logger import logger
 from aqt.theme import theme_manager
 from platform import system, version, release
 from ctypes import *
-from aqt.qt import (
-    Qt,
-)
+from aqt.qt import Qt
+from aqt import mw
 
 dwmapi = None
 ## Darkmode windows titlebar thanks to @miere43
 def set_dark_titlebar(window, dwmapi) -> None:
 	if dwmapi:
-		# Contanki compatibility fix
-		children = window.children()
-		for i,qchild in enumerate([str(x) for x in children]):
-			if "Contanki" in qchild:
-				# Set Contanki window to be on top, making it possible for being transparent
-				children[i].setAttribute(Qt.WidgetAttribute.WA_AlwaysStackOnTop)
-		
+		# Contanki compatibility fix, don't set NatieWindow on any dialogs
+		mw.app.setAttribute(Qt.ApplicationAttribute.AA_DontCreateNativeWidgetSiblings)
 		handler_window = c_void_p(int(window.winId()))
+
 		DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = c_int(19)
 		DWMWA_USE_IMMERSIVE_DARK_MODE = c_int(20)
 		windows_version = int(version().split('.')[2])

--- a/utils/dark_title_bar.py
+++ b/utils/dark_title_bar.py
@@ -1,0 +1,42 @@
+from .logger import logger
+from aqt.theme import theme_manager
+from platform import system, version, release
+from ctypes import *
+from aqt.qt import (
+    Qt,
+)
+
+dwmapi = None
+## Darkmode windows titlebar thanks to @miere43
+def set_dark_titlebar(window, dwmapi) -> None:
+	if dwmapi:
+		# Contanki compatibility fix
+		children = window.children()
+		for i,qchild in enumerate([str(x) for x in children]):
+			if "Contanki" in qchild:
+				# Set Contanki window to be on top, making it possible for being transparent
+				children[i].setAttribute(Qt.WidgetAttribute.WA_AlwaysStackOnTop)
+		
+		handler_window = c_void_p(int(window.winId()))
+		DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = c_int(19)
+		DWMWA_USE_IMMERSIVE_DARK_MODE = c_int(20)
+		windows_version = int(version().split('.')[2])
+		attribute = DWMWA_USE_IMMERSIVE_DARK_MODE if windows_version >= 18985 else DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1
+		if windows_version >= 17763 and int(release()) >= 10:
+			dwmapi.DwmSetWindowAttribute(handler_window, attribute, byref(c_int(1)), c_size_t(4))
+			pass
+
+def set_dark_titlebar_qt(obj, dwmapi, fix=True) -> None:
+	if dwmapi and theme_manager.get_night_mode():
+		set_dark_titlebar(obj, dwmapi)
+	# Trick to refresh the titlebar after dark titlebar is set
+	if fix:
+		obj.showFullScreen()
+		obj.showNormal()
+
+if system() == "Windows" and theme_manager.get_night_mode():
+	dwmapi = WinDLL("dwmapi")
+	if dwmapi:
+		dwmapi.DwmSetWindowAttribute.argtypes = [c_void_p, c_int, c_void_p, c_size_t]
+		dwmapi.DwmSetWindowAttribute.restype = c_int
+logger.debug(dwmapi)

--- a/utils/dialog.py
+++ b/utils/dialog.py
@@ -83,7 +83,6 @@ class AnkiRedesignThemeEditor(QDialog):
         size_policy.setHeightForWidth(self.sizePolicy().hasHeightForWidth())
         return size_policy
 
-
 class AnkiRedesignConfigDialog(QDialog):
     def __init__(self, parent: QWidget, *args, **kwargs):
         super().__init__(parent=parent or mw, *args, **kwargs)
@@ -98,13 +97,15 @@ class AnkiRedesignConfigDialog(QDialog):
         # Loads theme color
         self.theme_colors = themes_parsed.get("colors")
         self.updates = []
-        # self.theme_general = ["TEXT_FG", "WINDOW_BG", "FRAME_BG", "BUTTON_BG", "BUTTON_FOCUS_BG", "TOOLTIP_BG", "BORDER", "MEDIUM_BORDER", "FAINT_BORDER", "HIGHLIGHT_BG", "HIGHLIGHT_FG", "LINK", "DISABLED", "SLIGHTLY_GREY_TEXT", "FOCUS_SHADOW"]
-        # self.theme_decks = ["CURRENT_DECK", "NEW_COUNT", "LEARN_COUNT", "REVIEW_COUNT", "ZERO_COUNT"]
-        # self.theme_browse = ["BURIED_FG", "SUSPENDED_FG", "MARKED_BG", "FLAG1_BG", "FLAG1_FG", "FLAG2_BG", "FLAG2_FG", "FLAG3_BG", "FLAG3_FG", "FLAG4_BG", "FLAG4_FG", "FLAG5_BG", "FLAG5_FG", "FLAG6_BG", "FLAG6_FG", "FLAG7_BG", "FLAG7_FG"]
-        self.theme_general = ['FG', 'FG_DISABLED', 'FG_FAINT', 'FG_LINK', 'FG_SUBTLE'] + ['CANVAS', 'CANVAS_CODE', 'CANVAS_ELEVATED', 'CANVAS_INSET', 'CANVAS_OVERLAY']
-        self.theme_decks = ['BORDER', 'BORDER_FOCUS', 'BORDER_STRONG', 'BORDER_SUBTLE'] + ['BUTTON_BG', 'BUTTON_DISABLED', 'BUTTON_GRADIENT_END', 'BUTTON_GRADIENT_START', 'BUTTON_HOVER_BORDER', 'BUTTON_PRIMARY_BG', 'BUTTON_PRIMARY_DISABLED', 'BUTTON_PRIMARY_GRADIENT_END', 'BUTTON_PRIMARY_GRADIENT_START']
-        self.theme_browse = ['ACCENT_CARD', 'ACCENT_DANGER', 'ACCENT_NOTE'] + ['STATE_BURIED', 'STATE_LEARN', 'STATE_MARKED', 'STATE_NEW', 'STATE_REVIEW', 'STATE_SUSPENDED'] + ['FLAG_1', 'FLAG_2', 'FLAG_3', 'FLAG_4', 'FLAG_5', 'FLAG_6', 'FLAG_7']
-        self.theme_extra = ['SCROLLBAR_BG', 'SCROLLBAR_BG_ACTIVE', 'SCROLLBAR_BG_HOVER'] + ['HIGHLIGHT_BG', 'HIGHLIGHT_FG'] + ['SELECTED_BG', 'SELECTED_FG'] + ['SHADOW', 'SHADOW_FOCUS', 'SHADOW_INSET', 'SHADOW_SUBTLE']
+        self.theme_general = ["TEXT_FG", "WINDOW_BG", "FRAME_BG", "BUTTON_BG", "BUTTON_FOCUS_BG", "TOOLTIP_BG", "BORDER", "MEDIUM_BORDER", "FAINT_BORDER", "HIGHLIGHT_BG", "HIGHLIGHT_FG" , "LINK", "DISABLED", "SLIGHTLY_GREY_TEXT", "FOCUS_SHADOW"]
+        self.theme_decks = ["CURRENT_DECK", "NEW_COUNT", "LEARN_COUNT", "REVIEW_COUNT", "ZERO_COUNT"]
+        self.theme_browse = ["BURIED_FG", "SUSPENDED_FG", "MARKED_BG", "FLAG1_BG", "FLAG1_FG", "FLAG2_BG", "FLAG2_FG", "FLAG3_BG", "FLAG3_FG", "FLAG4_BG", "FLAG4_FG", "FLAG5_BG", "FLAG5_FG", "FLAG6_BG", "FLAG6_FG", "FLAG7_BG", "FLAG7_FG"]
+        self.theme_extra = []
+        if anki_version >= (2, 1, 56):
+            self.theme_general = ['FG', 'FG_DISABLED', 'FG_FAINT', 'FG_LINK', 'FG_SUBTLE'] + ['CANVAS', 'CANVAS_CODE', 'CANVAS_ELEVATED', 'CANVAS_INSET', 'CANVAS_OVERLAY']
+            self.theme_decks = ['BORDER', 'BORDER_FOCUS', 'BORDER_STRONG', 'BORDER_SUBTLE'] + ['BUTTON_BG', 'BUTTON_DISABLED', 'BUTTON_GRADIENT_END', 'BUTTON_GRADIENT_START', 'BUTTON_HOVER_BORDER', 'BUTTON_PRIMARY_BG', 'BUTTON_PRIMARY_DISABLED', 'BUTTON_PRIMARY_GRADIENT_END', 'BUTTON_PRIMARY_GRADIENT_START']
+            self.theme_browse = ['ACCENT_CARD', 'ACCENT_DANGER', 'ACCENT_NOTE'] + ['STATE_BURIED', 'STATE_LEARN', 'STATE_MARKED', 'STATE_NEW', 'STATE_REVIEW', 'STATE_SUSPENDED'] + ['FLAG_1', 'FLAG_2', 'FLAG_3', 'FLAG_4', 'FLAG_5', 'FLAG_6', 'FLAG_7']
+            self.theme_extra = ['SCROLLBAR_BG', 'SCROLLBAR_BG_ACTIVE', 'SCROLLBAR_BG_HOVER'] + ['HIGHLIGHT_BG', 'HIGHLIGHT_FG'] + ['SELECTED_BG', 'SELECTED_FG'] + ['SHADOW', 'SHADOW_FOCUS', 'SHADOW_INSET', 'SHADOW_SUBTLE']
 
         # Root layout
         self.root_layout = QVBoxLayout(self)

--- a/utils/dialog.py
+++ b/utils/dialog.py
@@ -388,6 +388,7 @@ class AnkiRedesignConfigDialog(QDialog):
         config["theme"] = theme
         write_config(config)
         config = get_config()
+        logger.debug(config)
 
         # Write and update theme
         color_mode = 3 if theme_manager.get_night_mode() else 2  # 2 = light and 3 = dark

--- a/utils/dialog.py
+++ b/utils/dialog.py
@@ -14,7 +14,7 @@ if module_has_attribute("anki.lang", "current_lang"):
     from anki.lang import current_lang, lang_to_disk_lang, compatMap
 else:
     from anki.lang import currentLang as current_lang, lang_to_disk_lang, compatMap
-
+from .dark_title_bar import set_dark_titlebar_qt, dwmapi
 anki_version = tuple(int(segment) for segment in appVersion.split("."))
 
 theme = config['theme']
@@ -38,6 +38,7 @@ class AnkiRedesignThemeEditor(QDialog):
         self.setSizePolicy(self.make_size_policy())
         self.setMinimumSize(420, 420)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+        set_dark_titlebar_qt(self, dwmapi, fix=False)
         # Root layout
         self.root_layout = QVBoxLayout(self)
         # Main layout
@@ -92,6 +93,7 @@ class AnkiRedesignConfigDialog(QDialog):
         self.setSizePolicy(self.make_size_policy())
         self.setMinimumSize(420, 580)
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
+        set_dark_titlebar_qt(self, dwmapi, fix=False)
 
         # Color/theme
         # Loads theme color

--- a/utils/dialog.py
+++ b/utils/dialog.py
@@ -465,7 +465,10 @@ def apply_theme(colors) -> None:
     logger.debug(colors)
     if getattr(theme_manager, "_default_style", False):
         mw.app.setStyle(QStyleFactory.create(theme_manager._default_style))
-        mw.app.setPalette(theme_manager.default_palette)
+        if getattr(theme_manager, "default_palette", False):
+            mw.app.setPalette(theme_manager.default_palette)
+        else:
+            theme_manager._apply_palette(mw.app)
     # Load and apply palette
     palette = QPalette()
     # Update palette

--- a/utils/themes.py
+++ b/utils/themes.py
@@ -36,6 +36,13 @@ def get_theme(theme: str) -> dict:
     themes_parsed = json.loads(open(themes[theme], encoding='utf-8').read())
     theme_colors = themes_parsed.get("colors")
 
+    # Add extra color_keys on theme files if not exist (ReColor compatible)
+    if not theme_colors.get("BUTTON_FOCUS_BG", False):
+        theme_colors["BUTTON_FOCUS_BG"] = ["Button Focus Background", "", "#0093d0", "#0093d0", "--button-focus-bg"]
+    if not theme_colors.get("FOCUS_SHADOW", False):
+        theme_colors["FOCUS_SHADOW"] = ["Focus Shadow", "", "#ff93d0", "#0093d0", "--focus-shadow-color"]
+    if theme_colors.get("BUTTON_BG", False):
+        theme_colors["BUTTON_BG"] =  theme_colors["BUTTON_BG"][:-1]+["--button-bg"]
     # New color keys
     theme_fixes = [
         # New Accent (Browser)
@@ -59,10 +66,10 @@ def get_theme(theme: str) -> dict:
         {"key": "BUTTON_GRADIENT_END", "name": "Button Gradient End", "comment": "End value of default button gradient", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-grandient-end"]},
         {"key": "BUTTON_GRADIENT_START", "name": "Button Gradient Start", "comment": "Start value of default button gradient", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-gradient-start"]},
         {"key": "BUTTON_HOVER_BORDER", "name": "Button Hover Border", "comment": "Border color of default button in hover state", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-hover-border"]},
-        {"key": "BUTTON_PRIMARY_BG", "name": "Button Primary Background", "comment": "Background color of primary button", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-primary-bg"]},
-        {"key": "BUTTON_PRIMARY_DISABLED", "name": "Button Primary Disabled", "comment": "Background color of primary button in disabled state", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-primary-disabled"]},
-        {"key": "BUTTON_PRIMARY_GRADIENT_END", "name": "Button Primary Gradient End", "comment": "End value of primary button gradient", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-primary-gradient-end"]},
-        {"key": "BUTTON_PRIMARY_GRADIENT_START", "name": "Button Primary Gradient Start", "comment": "Start value of primary button gradient", "data": theme_colors["BUTTON_BG"][:-1] + ["--button-primary-gradient-start"]},
+        {"key": "BUTTON_PRIMARY_BG", "name": "Button Primary Background", "comment": "Background color of primary button", "data": theme_colors["BUTTON_FOCUS_BG"][:-1] + ["--button-primary-bg"]},
+        {"key": "BUTTON_PRIMARY_DISABLED", "name": "Button Primary Disabled", "comment": "Background color of primary button in disabled state", "data": theme_colors["BUTTON_FOCUS_BG"][:-1] + ["--button-primary-disabled"]},
+        {"key": "BUTTON_PRIMARY_GRADIENT_END", "name": "Button Primary Gradient End", "comment": "End value of primary button gradient", "data": theme_colors["BUTTON_FOCUS_BG"][:-1] + ["--button-primary-gradient-end"]},
+        {"key": "BUTTON_PRIMARY_GRADIENT_START", "name": "Button Primary Gradient Start", "comment": "Start value of primary button gradient", "data": theme_colors["BUTTON_FOCUS_BG"][:-1] + ["--button-primary-gradient-start"]},
         # New Foreground
         {"key": "FG", "name": "Foreground", "comment": "Default text/icon color", "data": theme_colors["TEXT_FG"][:-1] + ["--fg"]},
         {"key": "FG_DISABLED", "name": "Foreground Disabled", "comment": "Foreground color of disabled UI elements", "data": theme_colors["DISABLED"][:-1] + ["--fg-disabled"]},
@@ -77,16 +84,16 @@ def get_theme(theme: str) -> dict:
         {"key": "FLAG_5", "name": "Flag 5 (pink)", "comment": "", "data": theme_colors["FLAG5_FG"][:-1] + ["--flag-5"]},
         {"key": "FLAG_6", "name": "Flag 6 (turquoise)", "comment": "", "data": theme_colors["FLAG6_FG"][:-1] + ["--flag-6"]},
         {"key": "FLAG_7", "name": "Flag 7 (purple)", "comment": "", "data": theme_colors["FLAG7_FG"][:-1] + ["--flag-7"]},
+        # New Selected
+        {"key": "SELECTED_BG", "name": "Selected Background", "comment": "Background color of selected text", "data": theme_colors["HIGHLIGHT_BG"][:-1] + ["--selected-bg"]},
+        {"key": "SELECTED_FG", "name": "Selected Foreground", "comment": "Foreground color of selected text", "data": theme_colors["HIGHLIGHT_FG"][:-1] + ["--selected-fg"]},
         # New Highlight
-        {"key": "HIGHLIGHT_BG", "name": "Highlight Background", "comment": "Background color of highlighted items", "data": theme_colors["HIGHLIGHT_BG"][:-1] + ["--selected-bg"]},
-        {"key": "HIGHLIGHT_FG", "name": "Highlight Foreground", "comment": "Foreground color of highlighted items", "data": theme_colors["HIGHLIGHT_FG"][:-1] + ["--selected-fg"]},
+        {"key": "HIGHLIGHT_BG", "name": "Highlight Background", "comment": "Background color of highlighted items", "data": theme_colors["HIGHLIGHT_BG"][:-1] + ["--highlighted-bg"]},
+        {"key": "HIGHLIGHT_FG", "name": "Highlight Foreground", "comment": "Foreground color of highlighted items", "data": theme_colors["HIGHLIGHT_FG"][:-1] + ["--highlighted-fg"]},
         # New Scrollbar
         {"key": "SCROLLBAR_BG", "name": "Scrollbar Background", "comment": "Background of scrollbar in idle state (Win/Lin only)", "data": theme_colors["FRAME_BG"][:-1] + ["--scrollbar-bg"]},
         {"key": "SCROLLBAR_BG_ACTIVE", "name": "Scrollbar Background Active", "comment": "Background of scrollbar in pressed state (Win/Lin only)", "data": theme_colors["TOOLTIP_BG"][:-1] + ["--scrollbar-bg-active"]},
         {"key": "SCROLLBAR_BG_HOVER", "name": "Scrollbar Background Hover", "comment": "Background of scrollbar in hover state (Win/Lin only)", "data": theme_colors["BORDER"][:-1] + ["--scrollbar-bg-hover"]},
-        # New Selected
-        {"key": "SELECTED_BG", "name": "Selected Background", "comment": "Background color of selected text", "data": theme_colors["HIGHLIGHT_BG"][:-1] + ["--selected-bg"]},
-        {"key": "SELECTED_FG", "name": "Selected Foreground", "comment": "Foreground color of selected text", "data": theme_colors["HIGHLIGHT_FG"][:-1] + ["--selected-fg"]},
         # New Shadow
         {"key": "SHADOW", "name": "Shadow", "comment": "Default box-shadow color", "data": theme_colors["FOCUS_SHADOW"][:-1] + ["--shadow"]},
         {"key": "SHADOW_FOCUS", "name": "Shadow Focus", "comment": "Box-shadow color for elements in focused state", "data": theme_colors["FOCUS_SHADOW"][:-1] + ["--shadow-focus"]},
@@ -109,6 +116,7 @@ def get_theme(theme: str) -> dict:
             temp_data = theme_keys["data"]
             fixed.append(key)
             theme_colors[key] = [theme_keys["name"], theme_keys["comment"], temp_data[-3], temp_data[-2], temp_data[-1]]
+    # Fix existing colors with new theme_colors format
     for colors in theme_colors:
         if len(theme_colors[colors]) == 4 and colors not in fixed:
             temp_data = theme_colors[colors]
@@ -119,7 +127,7 @@ def get_theme(theme: str) -> dict:
         {"old": "WINDOW_BG", "new": "CANVAS"},
         {"old": "FRAME_BG", "new": "CANVAS_ELEVATED"},
         {"old": "TOOLTIP_BG", "new": "CANVAS_OVERLAY"},
-        {"old": "CURRENT_DECK", "new": "BUTTON_BG"},
+        {"old": "CURRENT_DECK", "new": "CANVAS_ELEVATED"},
         {"old": "TEXT_FG", "new": "FG"},
         {"old": "SLIGHTLY_GREY_TEXT", "new": "FG_FAINT"},
         {"old": "DISABLED", "new": "FG_DISABLED"},
@@ -130,7 +138,7 @@ def get_theme(theme: str) -> dict:
         {"old": "MEDIUM_BORDER", "new": "BORDER_STRONG"},
         {"old": "BUTTON_BG", "new": "BUTTON_BG"},
         {"old": "BUTTON_FOCUS_BG", "new": "BUTTON_PRIMARY_BG"},
-        {"old": "FOCUS_SHADOW", "new": "SHADOW_FOCUS"},
+        {"old": "FOCUS_SHADOW", "new": "SHADOW"},
         {"old": "HIGHLIGHT_BG", "new": "HIGHLIGHT_BG"},
         {"old": "HIGHLIGHT_FG", "new": "HIGHLIGHT_FG"},
 
@@ -164,7 +172,6 @@ def get_theme(theme: str) -> dict:
             theme_colors[theme_keys["old"]] = [old_data[0], old_data[1], new_data[-3], new_data[-2], old_data[-1]]
         else:
             theme_colors[theme_keys["old"]] = theme_colors[theme_keys["new"]]
-
 
     themes_parsed["colors"] = theme_colors
     return themes_parsed


### PR DESCRIPTION
This PR adds the following changes and fixes while being completely backwards compatible with older Anki versions:
New version compatibility fix:
- [x] closes #44 - 2.1.55 
- [x] closes #59 - 2.1.55

Bugfixes: 
- [x] closes #52 - small buttons in "add"-window
- [x] closes #55 - re-add dark windows title bar
- [x] closes #60 - fix unnecessary horizontal slider in "deck"-window

Add-on compatibility fixes:
- [x] Visual issue with Contanki
- [x] Visual issue with NDFS
- [x] closes #51 - Visual issue with ARBb